### PR TITLE
LLVM 20.1.2 -> 20.1.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,15 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743613625,
-        "narHash": "sha256-N4hv3YDFs2yA/NBYNQK1o4AaNzLdBKqeePquk+t+QiA=",
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b19d7721ae9325afb9ba3729a09a18d203ccd6e6",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "e9b7f2f",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -27,7 +27,6 @@
       },
       "original": {
         "owner": "NixOS",
-        "ref": "e9b7f2f",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/e9b7f2f";
     flake-utils.url = "github:numtide/flake-utils/v1.0.0";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/e9b7f2f";
+    nixpkgs.url = "github:NixOS/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils/v1.0.0";
   };
 

--- a/packages/llzk_llvm/default.nix
+++ b/packages/llzk_llvm/default.nix
@@ -4,10 +4,7 @@
 let
   mkPackageBase = pkgs: {
     tools = llvmPackages.tools.extend (tpkgs: tpkgsOld: {
-      libllvm = (tpkgsOld.libllvm.override ({
-        # Skip tests since they take a long time to build and run
-        doCheck = false;
-      })).overrideAttrs (attrs: {
+      libllvm = tpkgsOld.libllvm.overrideAttrs (attrs: {
         cmakeFlags = attrs.cmakeFlags ++ [
           # Skip irrelevant targets
           "-DLLVM_TARGETS_TO_BUILD=host"
@@ -22,6 +19,8 @@ let
           "-DLLVM_ENABLE_Z3_SOLVER=ON"
         ];
         propagatedBuildInputs = attrs.propagatedBuildInputs ++ [pkgs.z3];
+        # Skip tests since they take a long time to build and run
+        doCheck = false;
       });
 
       mlir = pkgs.callPackage ./mlir/default.nix {

--- a/packages/llzk_llvm/default.nix
+++ b/packages/llzk_llvm/default.nix
@@ -6,10 +6,6 @@ let
   mkPackageBase = pkgs: {
     tools = llvmPackages.tools.extend (tpkgs: tpkgsOld: {
       libllvm = tpkgsOld.libllvm.overrideAttrs (attrs: {
-      libllvm = (tpkgsOld.libllvm.override ({
-        # Skip tests since they take a long time to build and run
-        doCheck = false;
-      })).overrideAttrs (attrs: {
         inherit cmakeBuildType;
         cmakeFlags = attrs.cmakeFlags ++ [
           # Skip irrelevant targets


### PR DESCRIPTION
- Update nixpkgs to get us the right version of llvm
- Fix change in llvm package call with `doCheck` attribute