### PR TITLE
Fix llvm-config in release mode

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     {
       packages = flake-utils.lib.flattenTree {
         inherit (pkgs) mlir mlir-debug;
-        # Prevent use of libllvm and llvm from nixpkgs, which will have 
+        # Prevent use of libllvm and llvm from nixpkgs, which will have
         # different versions than mlir/llvm built here.
         inherit (pkgs.llzk-llvmPackages) libllvm llvm;
       };

--- a/packages/llzk_llvm/default.nix
+++ b/packages/llzk_llvm/default.nix
@@ -21,7 +21,7 @@ let
           # Enable Z3 Solver for SMTSolver usage
           "-DLLVM_ENABLE_Z3_SOLVER=ON"
         ];
-        propagatedBuildInputs = attrs.propagatedBuildInputs ++ [pkgs.z3];
+        propagatedBuildInputs = attrs.propagatedBuildInputs ++ [llvmPackages.libcxx pkgs.z3];
         # Skip tests since they take a long time to build and run
         doCheck = false;
 


### PR DESCRIPTION
Using the `llvmPackages.libcxx` fixes an issue where the release build of llvm had a broken `llvm-config` binary (though it worked in debug mode, which is odd).