### PR TITLE
Pin nixpkgs to nixpkgs-unstable to ensure cached packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,15 +18,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758917213,
-        "narHash": "sha256-1oA6zZxSl8F1yCKEWnw8EdE1TGoifTWlwGdfUlAQ5Hs=",
+        "lastModified": 1761656231,
+        "narHash": "sha256-EiED5k6gXTWoAIS8yQqi5mAX6ojnzpHwAQTS3ykeYMg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1fb3d0b78eb00961e57bf274d980120dd8a48f82",
+        "rev": "e99366c665bdd53b7b500ccdc5226675cfc51f45",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils/v1.0.0";
   };
 

--- a/packages/llzk_llvm/default.nix
+++ b/packages/llzk_llvm/default.nix
@@ -3,8 +3,8 @@
 }:
 
 let
-  mkPackageBase = pkgs: {
-    tools = llvmPackages.tools.extend (tpkgs: tpkgsOld: {
+  mkPackageBase = pkgs: (
+    llvmPackages.overrideScope (tpkgs: tpkgsOld: {
       libllvm = tpkgsOld.libllvm.overrideAttrs (attrs: {
         inherit cmakeBuildType;
         pname = "${attrs.pname or "libllvm"}-${pkgs.lib.toLower cmakeBuildType}";
@@ -33,15 +33,11 @@ let
       mlir = pkgs.callPackage ./mlir/default.nix {
         inherit cmakeBuildType;
         inherit (tpkgs.libllvm) monorepoSrc version;
-        buildLlvmTools = tpkgs;
+        buildLlvmPackages = tpkgs;
         llvm_meta = llvmPackages.libllvm.meta;
         inherit (tpkgs) libllvm;
       };
-    });
-  };
-
-  mkPackage = pkgs:
-    let base = mkPackageBase pkgs;
-    in base // { inherit (base) tools; } // (pkgs.lib.attrsets.removeAttrs base.tools [ "extend" ]);
+    })
+  );
 in
-mkPackage
+mkPackageBase

--- a/packages/llzk_llvm/mlir/default.nix
+++ b/packages/llzk_llvm/mlir/default.nix
@@ -12,7 +12,7 @@
 , enableShared ? !stdenv.hostPlatform.isStatic
 , cmakeBuildType ? "Release"
 , enablePythonBindings ? false
-, buildLlvmTools
+, buildLlvmPackages
 , libxml2
 , libllvm
 }:
@@ -76,8 +76,8 @@ stdenv.mkDerivation rec {
     "-DMLIR_STANDALONE_BUILD=TRUE"
     "-DLLVM_TARGETS_TO_BUILD=host"
     "-DLLVM_ENABLE_DUMP=ON"
-    "-DMLIR_TABLEGEN_EXE=${buildLlvmTools.tblgen}/bin/mlir-tblgen"
-    "-DLLVM_TABLEGEN_EXE=${buildLlvmTools.tblgen}/bin/llvm-tblgen"
+    "-DMLIR_TABLEGEN_EXE=${buildLlvmPackages.tblgen}/bin/mlir-tblgen"
+    "-DLLVM_TABLEGEN_EXE=${buildLlvmPackages.tblgen}/bin/llvm-tblgen"
 
   ] ++ lib.optionals enablePythonBindings [
     # Enable Python bindings


### PR DESCRIPTION
Require nixpkgs to be based on nixpkgs-unstable, which will ensure that most of the packages in nixpkgs will be contained in the nixpkgs binary cache.

Also, the LLVM derivation override has been updated to be consistent with the recent refactoring that has occurred in upstream nixpkgs.

---

~~Technically, this is not needed~~, but I already did the work to refactor and cache the build. So here we are...