### PR TITLE
Disable LLVM assertions in release mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Nix package build
 /result
+
+# Miscellaneous
+.DS_Store

--- a/packages/llzk_llvm/default.nix
+++ b/packages/llzk_llvm/default.nix
@@ -3,6 +3,8 @@
 }:
 
 let
+  releaseBuild = cmakeBuildType == "Release" || cmakeBuildType == "RelWithDebInfo";
+
   mkPackageBase = pkgs: (
     llvmPackages.overrideScope (tpkgs: tpkgsOld: {
       libllvm = tpkgsOld.libllvm.overrideAttrs (attrs: {
@@ -17,7 +19,7 @@ let
           # Need the following to enable exceptions
           "-DLLVM_ENABLE_EH=ON"
           # Assertions are very useful for debugging
-          "-DLLVM_ENABLE_ASSERTIONS=ON"
+          "-DLLVM_ENABLE_ASSERTIONS=${if releaseBuild then "OFF" else "ON"}"
           # Enable Z3 Solver for SMTSolver usage
           "-DLLVM_ENABLE_Z3_SOLVER=ON"
         ];
@@ -25,7 +27,7 @@ let
         # Skip tests since they take a long time to build and run
         doCheck = false;
 
-        postInstall = pkgs.lib.optionalString (cmakeBuildType != "Release") ''
+        postInstall = pkgs.lib.optionalString (!releaseBuild) ''
           ln -s $dev/lib/cmake/llvm/LLVMExports-${pkgs.lib.toLower cmakeBuildType}.cmake $dev/lib/cmake/llvm/LLVMExports-release.cmake
         '' + attrs.postInstall;
       });


### PR DESCRIPTION
This causes some debug-related assertions to still be present in the code when they shouldn't be. This also hides some unused variable/member warnings, which cause issues with the llzk-rs CI, which uses a standard package version of llvm/mlir 20 (which doesn't have assertions enabled for release mode either).